### PR TITLE
fix: correct start script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ Atenxion EMR is a reference implementation of an electronic medical record syste
 ## Local Development
 1. Install dependencies with `npm install`.
 2. Start both the API and web dev servers:
-   ```bash
-   npm run dev
-   ```
-   The API runs on `http://localhost:8080` and the web client on `http://localhost:5173`.
+    ```bash
+    npm run dev
+    ```
+    The API runs on `http://localhost:8080` and the web client on `http://localhost:5173`.
+
+## Production Build
+To run the compiled server with the start script, build the project first:
+```bash
+npm run build
+npm start
+```
+This compiles TypeScript to the `dist` directory required by `node dist/src/index.js`.
 
 ## MySQL Setup
 Provision a MySQL instance and set the `DATABASE_URL` and `DIRECT_URL` in `.env`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc && cd client && npm install && npm run build",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "dev": "concurrently -k -n API,WEB \"tsx watch src/index.ts\" \"cd client && npm run dev\"",
     "dev:api": "tsx watch src/index.ts",
     "dev:web": "cd client && npm run dev",


### PR DESCRIPTION
## Summary
- run compiled server from dist/src/index.js
- document start script’s expected build output path

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fcors)*
- `npm test` *(fails: Cannot find module '/workspace/EMR2/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c24064002c832e812cead4c8541a13