### PR TITLE
Fix API queries for MySQL compatibility

### DIFF
--- a/src/modules/diagnoses/index.ts
+++ b/src/modules/diagnoses/index.ts
@@ -42,7 +42,7 @@ router.get('/', requireAuth, requireRole('Doctor', 'Admin'), async (req: Request
   const { q, from, to, limit = 20, offset = 0 } = parsed.data;
   const where: any = {};
   if (q) {
-    where.diagnosis = { contains: q, mode: 'insensitive' };
+    where.diagnosis = { contains: q };
   }
   if (from || to) {
     where.createdAt = {

--- a/src/modules/doctors/index.ts
+++ b/src/modules/doctors/index.ts
@@ -24,10 +24,10 @@ router.get('/', requireAuth, async (req: Request, res: Response) => {
   const { department, q } = parsed.data;
   const where: any = {};
   if (department) {
-    where.department = { contains: department, mode: 'insensitive' };
+    where.department = { contains: department };
   }
   if (q) {
-    where.name = { contains: q, mode: 'insensitive' };
+    where.name = { contains: q };
   }
   const doctors = await prisma.doctor.findMany({ where, orderBy: { name: 'asc' } });
   res.json(doctors);

--- a/src/modules/labs/index.ts
+++ b/src/modules/labs/index.ts
@@ -52,7 +52,7 @@ router.get('/', requireAuth, requireRole('Doctor', 'Admin'), async (req: Request
     where.visit = { patientId: patient_id };
   }
   if (test_name) {
-    where.testName = { contains: test_name, mode: 'insensitive' };
+    where.testName = { contains: test_name };
   }
   if (min !== undefined || max !== undefined) {
     where.resultValue = {


### PR DESCRIPTION
## Summary
- replace Postgres-specific patient search SQL with a Prisma query so GET /patients works with MySQL
- drop unsupported case-insensitive mode flags and raw Observation SQL so Prisma generates MySQL-compatible queries
- rebuild the insights cohort endpoint to derive the latest labs via Prisma rather than Postgres-only DISTINCT ON

## Testing
- `npm install` *(fails: npm 403 Forbidden downloading @types/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e827f9a8832ebf4d2094df1bfd93